### PR TITLE
Auto advance to gameplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@
 scene collection provided [here](KAYS2023.json), make sure to check everything is correct (especially audio devices)
 
 ### GAMEPLAY SCENE  
-| source            | url/path                                             | width | height | x         | y         |
-|-------------------|------------------------------------------------------|-------|--------|-----------|-----------|
-| vc_overlay*       | url from discord                                     | 500   | 50     | 16        | 909       |
-| name_overlays**   | http://localhost:24050/kays2023-stream-overlay/names/?id=0&flashBackground=false&color=red&placeholder=Waiting%20for%20P1%2E%2E%2E ***                                         | 638   | 360    | see below | see below |
-| osu clients**     |                                                      | 638   | 360    | see below | see below |
-| gameplay_overlay  | http://localhost:24050/kays2023-stream-overlay/main/ | 1920  | 1080   | 0         | 0         |
+| source             | url/path                                                                                                                               | width | height | x         | y         |
+|--------------------|----------------------------------------------------------------------------------------------------------------------------------------|-------|--------|-----------|-----------|
+| vc_overlay*        | url from discord                                                                                                                       | 500   | 50     | 16        | 909       |
+| name_overlays**    | http://localhost:24050/kays2023-stream-overlay/names/?id=0&flashBackground=false&color=red&placeholder=Waiting%20for%20P1%2E%2E%2E *** | 638   | 360    | see below | see below |
+| osu clients**      |                                                                                                                                        | 638   | 360    | see below | see below |
+| gameplay_overlay   | http://localhost:24050/kays2023-stream-overlay/main/                                                                                   | 1920  | 1080   | 0         | 0         |
+| mappool_overlay*** | <COPY & PASTE AS REFERENCE FROM **MAPPOOL SCENE**>                                                                                     | 2220  | 1080   | 1080      | 0         |
 
 <sup>*url from discord, replace custom css with [vc.css](vc.css)</sup><br>
 <sup>**placement according to the following table:</sup>
@@ -20,6 +21,9 @@ scene collection provided [here](KAYS2023.json), make sure to check everything i
 | 1      | 314  | 536  |
 | 2      | 968  | 176  |
 | 3      | 968  | 536  |
+<br>
+<sup>***Optional, but it makes it so the mappool `Interact` window doesn't go blank when in the gameplay scene. 
+It is not meant to be visible in the gameplay scene</sup>
 
 <sup>***base url for names: http://localhost:24050/kays2023-stream-overlay/names?id=0&flashBackground=false&color=red&placeholder=Waiting%20for%20P1%2E%2E%2E; edit `id`, `color`, and `placeholder` accordingly.
 
@@ -27,7 +31,7 @@ scene collection provided [here](KAYS2023.json), make sure to check everything i
 | source           | url/path                                                | width | height | x  | y    |
 |------------------|---------------------------------------------------------|-------|--------|----|------|
 | vc_overlay       |                                                         | 480   | 100    | 16 | 1014 |
-| mappool_overlay* | http://localhost:24050/kays2023-stream-overlay/mappool/ | 2220  | 700    | 0  | 220  |
+| mappool_overlay* | http://localhost:24050/kays2023-stream-overlay/mappool/ | 2220  | 1080   | 0  | 220  |
 
 ### Interacting with the mappool
 - Left click: left (red) team pick
@@ -38,11 +42,13 @@ scene collection provided [here](KAYS2023.json), make sure to check everything i
 <sup>*"control panel" featuring autopick function is off the screen, use the interact menu to activate</sup>
 
 ### INTRO SCENE
-| source           | url/path                                                | width | height | x | y   |
-|------------------|---------------------------------------------------------|-------|--------|---|-----|
-| intro_overlay*    | http://localhost:24050/kays2023-stream-overlay/intro/   | 1920  | 1080   | 0 | 0   |
+| source         | url/path                                              | width | height | x | y |
+|----------------|-------------------------------------------------------|-------|--------|---|---|
+| intro_overlay* | http://localhost:24050/kays2023-stream-overlay/intro/ | 2280  | 1080   | 0 | 0 |
 
-<sup>*data pulled from `_data/coming_up.json`, requires exchanging between matches</sup>
+<sup>*data pulled from `_data/coming_up.json`, will show the closest upcoming match by default. 
+Match schedule updates should be acquired by `git pull`ing. **In the event there are two matches at the same time,
+use `Interact` with the browser source to access the control panel off to the right of the window.**</sup>
 
 ### WINNER SCENE
 | source           | url/path                                                | width | height | x | y   |

--- a/mappool/index.html
+++ b/mappool/index.html
@@ -63,7 +63,10 @@
         <div id="pickButton" class="pickButton">RED PICK</div>
         <div id="switchPickButton" class="pickButton switchPickButton" onclick="switchPick()">SWITCH PICK</div>
         <div id="autoPickButton" class="pickButton switchPickButton" onclick="switchAutoPick()">AUTOPICK: OFF</div>
+        <hr>
         <div id="autoAdvanceButton" class="pickButton switchPickButton" onclick="switchAutoAdvance()">AUTO ADVANCE: OFF</div>
+        <div id="switchToMappoolScene" class="pickButton switchPickButton" onclick="switchToScene(mappool_scene_name)">SWITCH TO MAPPOOL</div>
+        <div id="switchToGameplayScene" class="pickButton switchPickButton" onclick="switchToScene(gameplay_scene_name)">SWITCH TO GAMEPLAY</div>
     </div>
     <script src="index.js"></script>
 </body>

--- a/mappool/index.html
+++ b/mappool/index.html
@@ -63,6 +63,7 @@
         <div id="pickButton" class="pickButton">RED PICK</div>
         <div id="switchPickButton" class="pickButton switchPickButton" onclick="switchPick()">SWITCH PICK</div>
         <div id="autoPickButton" class="pickButton switchPickButton" onclick="switchAutoPick()">AUTOPICK: OFF</div>
+        <div id="autoAdvanceButton" class="pickButton switchPickButton" onclick="switchAutoAdvance()">AUTO ADVANCE: OFF</div>
     </div>
     <script src="index.js"></script>
 </body>

--- a/mappool/index.js
+++ b/mappool/index.js
@@ -1,4 +1,11 @@
 let mappool, stage_data;
+
+/** maps selected beatmap to scene transition timeout id
+ * @type {Object.<number, number>} dict
+ */
+let selectedMapsTransitionTimeout = {};
+const pick_to_transition_delay_ms = 10000;
+const gameplay_scene_name = "gameplay";
 const point_rotation_red = [-12, 15, -3, 18, 9, 1, -19];
 const point_rotation_blue = [-8, -14, 16, 0, 18, 6, 15];
 (async () => {
@@ -16,6 +23,7 @@ socket.onerror = error => { console.log('Socket Error: ', error); };
 
 let pick_button = document.getElementById('pickButton');
 let autopick_button = document.getElementById('autoPickButton');
+let autoadvance_button = document.getElementById('autoAdvanceButton');
 
 let red_name = document.getElementById('red-name');
 let red_points = document.getElementById('red-points');
@@ -46,6 +54,7 @@ let redName = 'Red Team', blueName = 'Blue Team';
 let tempMapID = 0;
 let currentPicker = 'red';
 let enableAutoPick = false;
+let enableAutoAdvance = false;
 let selectedMaps = [];
 
 socket.onmessage = async event => {
@@ -299,6 +308,12 @@ const pickMap = (bm, playerName, color) => {
 	lastPicked = bm;
 	switchPick(color);
 	selectedMaps.push(bm.beatmapID);
+	if (enableAutoAdvance) {
+		selectedMapsTransitionTimeout[bm.beatmapID] = setTimeout(() => {
+			console.log(`hey, ${bm.beatmapID} was picked`);
+			window.obsstudio.setCurrentScene(gameplay_scene_name);
+		}, pick_to_transition_delay_ms);
+	}
 
 	bm.top.style.backgroundColor = `var(--${color})`;
 	bm.image.style.borderColor = `var(--${color}-darker)`;
@@ -317,6 +332,7 @@ const banMap = (bm, playerName, color) => {
 }
 
 const resetMap = bm => {
+	clearTimeout(selectedMapsTransitionTimeout[bm.beatmapID]);
 	selectedMaps = selectedMaps.filter(e => e != bm.beatmapID);
 	bm.top.style.backgroundColor = `var(--accent)`;
 	bm.image.style.borderColor = `var(--accent-dark)`;
@@ -347,6 +363,19 @@ const switchAutoPick = () => {
 		enableAutoPick = true;
 		autopick_button.innerHTML = 'AUTOPICK: ON';
 		autopick_button.style.backgroundColor = '#9ffcb3';
+	}
+}
+
+const switchAutoAdvance = () => {
+	if (enableAutoAdvance) {
+		enableAutoAdvance = false;
+		autoadvance_button.innerHTML = 'AUTO ADVANCE: OFF';
+		autoadvance_button.style.backgroundColor = '#fc9f9f';
+	}
+	else {
+		enableAutoAdvance = true;
+		autoadvance_button.innerHTML = 'AUTO ADVANCE: ON';
+		autoadvance_button.style.backgroundColor = '#9ffcb3';
 	}
 }
 

--- a/mappool/index.js
+++ b/mappool/index.js
@@ -6,6 +6,8 @@ let mappool, stage_data;
 let selectedMapsTransitionTimeout = {};
 const pick_to_transition_delay_ms = 10000;
 const gameplay_scene_name = "gameplay";
+const mappool_scene_name = "mappool";
+
 const point_rotation_red = [-12, 15, -3, 18, 9, 1, -19];
 const point_rotation_blue = [-8, -14, 16, 0, 18, 6, 15];
 (async () => {
@@ -311,7 +313,7 @@ const pickMap = (bm, playerName, color) => {
 	if (enableAutoAdvance) {
 		selectedMapsTransitionTimeout[bm.beatmapID] = setTimeout(() => {
 			console.log(`hey, ${bm.beatmapID} was picked`);
-			window.obsstudio.setCurrentScene(gameplay_scene_name);
+			switchToScene(gameplay_scene_name);
 		}, pick_to_transition_delay_ms);
 	}
 
@@ -377,6 +379,10 @@ const switchAutoAdvance = () => {
 		autoadvance_button.innerHTML = 'AUTO ADVANCE: ON';
 		autoadvance_button.style.backgroundColor = '#9ffcb3';
 	}
+}
+
+const switchToScene = (scene_name) => {
+	window.obsstudio.setCurrentScene(scene_name);
 }
 
 window.onload = function () {

--- a/mappool/style.css
+++ b/mappool/style.css
@@ -235,7 +235,8 @@ html {
     background-color: #bebebe;
 }
 
-#autoPickButton {
+#autoPickButton,
+#autoAdvanceButton {
     background-color: #fc9f9f;
 }
 


### PR DESCRIPTION
- adds a toggle in mappool overlay to toggle auto scene advance to gameplay. default is 10s after a map pick to switch to gameplay scene in OBS (a la Lazer style)
- adds manual scene switch button to mappool overlay to allow switching scenes from within the mappool `Interact` window rather than needing to use hotkeys/switch to main OBS window
- updates README.md to include instructions for auto-advance as well as OBS source transforms
